### PR TITLE
Fixed bug with certain kinds of error reporting

### DIFF
--- a/wildewidgets/views/json.py
+++ b/wildewidgets/views/json.py
@@ -212,4 +212,4 @@ class WildewidgetDispatch(WidgetInitKwargsMixin, View):
                         instance.args = initargs
                         instance.kwargs = initkwargs
                         return instance.dispatch(request, *args, **kwargs)
-        return Http404("Not Found: Wildewidget class not found")
+        raise Http404("Not Found: Wildewidget class not found")

--- a/wildewidgets/views/tables.py
+++ b/wildewidgets/views/tables.py
@@ -107,7 +107,7 @@ class TableActionFormView(View):
         checkboxes = request.POST.getlist("checkbox")
         action = request.POST.get("action")
         if not action or not checkboxes:
-            return Http404("POST request did not include the necessary fields")
+            raise Http404("POST request did not include the necessary fields")
         self.process_form_action(action, checkboxes)
         if not self.url:
             msg = f"You must set a url attribute on {self.__class__.__name__}"


### PR DESCRIPTION
Http404 is an exception, not an HTTPResponse object. You need to raise it, rather than return it, because middleware code expects an HTTPResponse, and will attempt to process a returned object like one, reading attributes that an Http404 doesn't have.