### PR TITLE
fix: groups_required needed to be a list of strings to be compared with user_groups.

### DIFF
--- a/wildewidgets/views/permission.py
+++ b/wildewidgets/views/permission.py
@@ -259,7 +259,7 @@ class PermissionRequiredMixin(AccessMixin):
 
         """
         if groups_required is None:
-            groups_required = self.get_groups_required()
+            groups_required = [group.name for group in self.get_groups_required()]
         if permissions_required is None:
             permissions_required = self.get_permissions_required()
         if self.required_model_permissions:


### PR DESCRIPTION
`groups_required` was a list of group objects while `user_groups` was a list of group names. Updated to get a list of group group name after calling `self.get_groups_required()` so they can compare correctly.